### PR TITLE
feat: folder for live TV recordings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes: 
       - /home/nathan/servarr/config/plex-config:/config
       - /mnt/data/media:/data/media
+      - /mnt/data/recordings:/data/recordings
       - /dev/shm:/transcode
     ports:
       - 32400:32400 # enable local access

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,7 @@ usermod -a -G servarr tautulli
 
 # Make directories
 mkdir -p /mnt/data/{torrents,media}/{tv,movies,4ktv,4kmovies}
+mkdir -p /mnt/data/recordings/{tv,movies}
 mkdir -p config/{plex,overseerr,sonarr,4ksonarr,radarr,4kradarr,bazarr,4kbazarr,prowlarr,qbittorrent,maintainerr,4kmaintainerr,tautulli,wizarr,gluetun}-config
 mkdir -p /mnt/kopia
 mkdir -p /home/nathan/kopia/{config,cache,logs}


### PR DESCRIPTION
This pull request adds support for a new `recordings` directory to the media server setup, ensuring both the Docker configuration and the setup script are updated accordingly.

Media directory updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R19): Added a new volume mapping for `/mnt/data/recordings` to be accessible at `/data/recordings` in the Plex container.
* [`setup.sh`](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R32): Updated the setup script to create `/mnt/data/recordings/tv` and `/mnt/data/recordings/movies` directories if they don't already exist.