### PR TITLE
Fix recording folder ownership and remove cache rule

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -299,23 +299,6 @@ resource "cloudflare_ruleset" "cache_nathanjn_com" {
     description = "Cache static assets for nathanjn.com"
     enabled     = true
   }
-
-  rules {
-    action = "set_cache_settings"
-    action_parameters {
-      cache = true
-      cache_key {
-        cache_deception_armor      = true
-        ignore_query_strings_order = true
-      }
-      edge_ttl {
-        mode = "respect_origin"
-      }
-    }
-    expression  = "true"
-    description = "Cache everything"
-    enabled     = true
-  }
 }
 
 ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - /home/nathan/servarr/config/plex-config:/config
       - /mnt/data/media:/data/media
       - /mnt/data/recordings:/data/recordings
+      - /mnt/data/optimised:/data/optimised
       - /dev/shm:/transcode
     ports:
       - 32400:32400 # enable local access

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ usermod -a -G servarr tautulli
 
 # Make directories
 mkdir -p /mnt/data/{torrents,media}/{tv,movies,4ktv,4kmovies}
-mkdir -p /mnt/data/recordings/{tv,movies}
+mkdir -p /mnt/data/{recordings,optimised}/{tv,movies}
 mkdir -p config/{plex,overseerr,sonarr,4ksonarr,radarr,4kradarr,bazarr,4kbazarr,prowlarr,qbittorrent,maintainerr,4kmaintainerr,tautulli,wizarr,gluetun}-config
 mkdir -p /mnt/kopia
 mkdir -p /home/nathan/kopia/{config,cache,logs}
@@ -42,6 +42,7 @@ chown -R nathan:servarr /mnt/kopia
 chown -R nathan:servarr /home/nathan/kopia
 chown -R nathan:servarr /home/nathan/uptime-kuma
 chown -R plex:servarr /mnt/data/recordings
+chown -R plex:servarr /mnt/data/optimised
 chown -R plex:servarr config/plex-config
 chown -R overseerr:servarr config/overseerr-config
 chown -R sonarr:servarr config/sonarr-config

--- a/setup.sh
+++ b/setup.sh
@@ -41,6 +41,7 @@ chown -R nathan:servarr /mnt/data
 chown -R nathan:servarr /mnt/kopia
 chown -R nathan:servarr /home/nathan/kopia
 chown -R nathan:servarr /home/nathan/uptime-kuma
+chown -R plex:servarr /mnt/data/recordings
 chown -R plex:servarr config/plex-config
 chown -R overseerr:servarr config/overseerr-config
 chown -R sonarr:servarr config/sonarr-config


### PR DESCRIPTION
Update the ownership of the recordings folder to Plex and eliminate the cache everything rule for improved performance.