### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on_merge.yml
+++ b/.github/workflows/on_merge.yml
@@ -49,6 +49,8 @@ jobs:
     name: Run SSH command
     needs: terraform_apply
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Connect and run command on remote server
       uses: nathanjnorris/cloudflared-ssh-action@latest


### PR DESCRIPTION
Potential fix for [https://github.com/nathanjnorris/servarr/security/code-scanning/1](https://github.com/nathanjnorris/servarr/security/code-scanning/1)

To fix the problem, add an explicit minimal `permissions:` block to the `ssh_command` job in `.github/workflows/on_merge.yml`. Review the job's steps; the only GitHub resources potentially needed are read-only access to repository contents to use actions, or possibly none at all. The recommended minimal block is `permissions:\n  contents: read\n`. This should be inserted under `runs-on: ubuntu-latest` for the `ssh_command` job (after line 51), mirroring the approach in the other job (`terraform_apply`). No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
