### PR TITLE
Home assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ No modules.
 |------|------|
 | [cloudflare_access_application.bazarr4k_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
 | [cloudflare_access_application.bazarr_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
+| [cloudflare_access_application.ha_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
 | [cloudflare_access_application.kopia_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
 | [cloudflare_access_application.maintainerr_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
+| [cloudflare_access_application.matter_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
 | [cloudflare_access_application.prowlarr_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
 | [cloudflare_access_application.qbittorrent_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
 | [cloudflare_access_application.radarr4k_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
@@ -38,9 +40,12 @@ No modules.
 | [cloudflare_access_application.sonarr4k_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
 | [cloudflare_access_application.sonarr_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
 | [cloudflare_access_application.tautulli_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application) | resource |
+| [cloudflare_access_policy.google_assistant_ha](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.service_bazarr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.service_bazarr4k](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
+| [cloudflare_access_policy.service_ha](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.service_maintainerr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
+| [cloudflare_access_policy.service_matter](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.service_prowlarr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.service_qbittorrent](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.service_radarr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
@@ -50,8 +55,10 @@ No modules.
 | [cloudflare_access_policy.service_tautulli](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.user_bazarr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.user_bazarr4k](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
+| [cloudflare_access_policy.user_ha](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.user_kopia](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.user_maintainerr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
+| [cloudflare_access_policy.user_matter](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.user_prowlarr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.user_qbittorrent](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.user_radarr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
@@ -60,13 +67,16 @@ No modules.
 | [cloudflare_access_policy.user_sonarr4k](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_policy.user_tautulli](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy) | resource |
 | [cloudflare_access_service_token.github_actions](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_service_token) | resource |
+| [cloudflare_access_service_token.google_assistant](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_service_token) | resource |
 | [cloudflare_access_service_token.uptime_kuma](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_service_token) | resource |
 | [cloudflare_bot_management.bots_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/bot_management) | resource |
 | [cloudflare_r2_bucket.bucket-servarr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_bucket) | resource |
 | [cloudflare_record.bazarr4k_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
 | [cloudflare_record.bazarr_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
+| [cloudflare_record.ha_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
 | [cloudflare_record.kopia_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
 | [cloudflare_record.maintainerr_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
+| [cloudflare_record.matter_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
 | [cloudflare_record.overseerr_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
 | [cloudflare_record.plex_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
 | [cloudflare_record.prowlarr_nathanjn_com](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
@@ -123,5 +133,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_google_assistant_client_id"></a> [google\_assistant\_client\_id](#output\_google\_assistant\_client\_id) | Client ID for Google Assistant service token. |
+| <a name="output_google_assistant_client_secret"></a> [google\_assistant\_client\_secret](#output\_google\_assistant\_client\_secret) | Client secret for Google Assistant service token. |
 | <a name="output_servarr_tunnel_token"></a> [servarr\_tunnel\_token](#output\_servarr\_tunnel\_token) | Token used by a connector to authenticate and run the tunnel. |
 <!-- END_TF_DOCS -->

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -353,6 +353,13 @@ resource "cloudflare_access_service_token" "uptime_kuma" {
   duration   = "forever"
 }
 
+# Create a service token for Google Assistant to authenticate with Home Assistant
+resource "cloudflare_access_service_token" "google_assistant" {
+  account_id = var.account_id
+  name       = "Google Assistant"
+  duration   = "forever"
+}
+
 # # Create an Access application to control who can connect to SSH.
 # resource "cloudflare_access_application" "servarr_nathanjn_com" {
 #   zone_id                   = data.cloudflare_zone.nathanjn_com.id
@@ -746,11 +753,22 @@ resource "cloudflare_access_policy" "service_ha" {
   }
 }
 
+resource "cloudflare_access_policy" "google_assistant_ha" {
+  application_id = cloudflare_access_application.ha_nathanjn_com.id
+  zone_id        = data.cloudflare_zone.nathanjn_com.id
+  name           = "Google Assistant auth"
+  precedence     = "2"
+  decision       = "non_identity"
+  include {
+    service_token = [cloudflare_access_service_token.google_assistant.id]
+  }
+}
+
 resource "cloudflare_access_policy" "user_ha" {
   application_id = cloudflare_access_application.ha_nathanjn_com.id
   zone_id        = data.cloudflare_zone.nathanjn_com.id
   name           = "User auth"
-  precedence     = "2"
+  precedence     = "3"
   decision       = "allow"
   include {
     email = ["nathan.james.norris@gmail.com"]

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -165,6 +165,22 @@ resource "cloudflare_record" "status_nathanjn_com" {
   proxied = true
 }
 
+resource "cloudflare_record" "ha_nathanjn_com" {
+  zone_id = data.cloudflare_zone.nathanjn_com.id
+  name    = "ha"
+  value   = cloudflare_tunnel.servarr_tunnel.cname
+  type    = "CNAME"
+  proxied = true
+}
+
+resource "cloudflare_record" "matter_nathanjn_com" {
+  zone_id = data.cloudflare_zone.nathanjn_com.id
+  name    = "matter"
+  value   = cloudflare_tunnel.servarr_tunnel.cname
+  type    = "CNAME"
+  proxied = true
+}
+
 ###
 # Tunnel configuration 
 ###
@@ -249,6 +265,14 @@ resource "cloudflare_tunnel_config" "servarr_tunnel" {
     ingress_rule {
       hostname = "status.nathanjn.com"
       service  = "http://uptime-kuma:3001"
+    }
+    ingress_rule {
+      hostname = "ha.nathanjn.com"
+      service  = "http://home-assistant:8123"
+    }
+    ingress_rule {
+      hostname = "matter.nathanjn.com"
+      service  = "http://matter-server:5580"
     }
     ingress_rule {
       service = "http_status:404"
@@ -696,6 +720,68 @@ resource "cloudflare_access_policy" "user_kopia" {
   zone_id        = data.cloudflare_zone.nathanjn_com.id
   name           = "User auth"
   precedence     = "1"
+  decision       = "allow"
+  include {
+    email = ["nathan.james.norris@gmail.com"]
+  }
+}
+
+resource "cloudflare_access_application" "ha_nathanjn_com" {
+  zone_id                   = data.cloudflare_zone.nathanjn_com.id
+  name                      = "ha.nathanjn.com"
+  domain                    = "ha.nathanjn.com"
+  session_duration          = "2h"
+  auto_redirect_to_identity = true
+  allowed_idps              = ["97ed69f2-279d-4cef-bc29-65b6f7e915bf"]
+}
+
+resource "cloudflare_access_policy" "service_ha" {
+  application_id = cloudflare_access_application.ha_nathanjn_com.id
+  zone_id        = data.cloudflare_zone.nathanjn_com.id
+  name           = "Service auth"
+  precedence     = "1"
+  decision       = "non_identity"
+  include {
+    service_token = [cloudflare_access_service_token.uptime_kuma.id]
+  }
+}
+
+resource "cloudflare_access_policy" "user_ha" {
+  application_id = cloudflare_access_application.ha_nathanjn_com.id
+  zone_id        = data.cloudflare_zone.nathanjn_com.id
+  name           = "User auth"
+  precedence     = "2"
+  decision       = "allow"
+  include {
+    email = ["nathan.james.norris@gmail.com"]
+  }
+}
+
+resource "cloudflare_access_application" "matter_nathanjn_com" {
+  zone_id                   = data.cloudflare_zone.nathanjn_com.id
+  name                      = "matter.nathanjn.com"
+  domain                    = "matter.nathanjn.com"
+  session_duration          = "2h"
+  auto_redirect_to_identity = true
+  allowed_idps              = ["97ed69f2-279d-4cef-bc29-65b6f7e915bf"]
+}
+
+resource "cloudflare_access_policy" "service_matter" {
+  application_id = cloudflare_access_application.matter_nathanjn_com.id
+  zone_id        = data.cloudflare_zone.nathanjn_com.id
+  name           = "Service auth"
+  precedence     = "1"
+  decision       = "non_identity"
+  include {
+    service_token = [cloudflare_access_service_token.uptime_kuma.id]
+  }
+}
+
+resource "cloudflare_access_policy" "user_matter" {
+  application_id = cloudflare_access_application.matter_nathanjn_com.id
+  zone_id        = data.cloudflare_zone.nathanjn_com.id
+  name           = "User auth"
+  precedence     = "2"
   decision       = "allow"
   include {
     email = ["nathan.james.norris@gmail.com"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -307,6 +307,7 @@ services:
       default:
       macvlan1:
         ipv4_address: 192.168.8.13
+        ipv6_address: fd69:59dc:f817:b798::13
     environment:
       - PUID=13011
       - PGID=13000
@@ -328,6 +329,7 @@ services:
       default:
       macvlan1:
         ipv4_address: 192.168.8.14
+        ipv6_address: fd69:59dc:f817:b798::14
     environment:
       - TZ=Australia/Brisbane
     read_only: true
@@ -407,3 +409,5 @@ networks:
         - subnet: 192.168.8.0/24
           ip_range: 192.168.8.12/30
           gateway: 192.168.8.1
+        - subnet: fd69:59dc:f817:b798::/64
+          gateway: fd69:59dc:f817:b798:9683:c4ff:feb4:a502

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -300,6 +300,41 @@ services:
       - TS_HOSTNAME=vpn
     restart: always
 
+  home-assistant:
+    image: lscr.io/linuxserver/homeassistant:latest
+    container_name: home-assistant
+    networks:
+      default:
+      macvlan1:
+        ipv4_address: 192.168.8.13
+    environment:
+      - PUID=13011
+      - PGID=13000
+      - UMASK=002
+      - TZ=Australia/Brisbane
+    volumes:
+      - /home/nathan/servarr/config/home-assistant-config:/config
+      - /run/dbus:/run/dbus:ro
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    restart: always
+
+  matter-server:
+    image: ghcr.io/matter-js/matterjs-server:latest
+    container_name: matter-server
+    user: 13012:13000
+    networks:
+      default:
+      macvlan1:
+        ipv4_address: 192.168.8.14
+    environment:
+      - TZ=Australia/Brisbane
+    read_only: true
+    volumes:
+      - /home/nathan/servarr/config/matter-server-config:/data
+    restart: always
+
 # Container updates
   watchtower:
     image: containrrr/watchtower:latest
@@ -360,4 +395,15 @@ networks:
         - subnet: 192.168.8.0/24
           # The ip_range 192.168.8.4/30 provides only 2 usable IP addresses (192.168.8.5 for the container, 192.168.8.6 for the host).
           ip_range: 192.168.8.4/30
+          gateway: 192.168.8.1
+  macvlan1:
+    driver: macvlan
+    enable_ipv6: true
+    driver_opts:
+      parent: enp1s0
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.8.0/24
+          ip_range: 192.168.8.12/30
           gateway: 192.168.8.1

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,11 +9,6 @@ output "google_assistant_client_id" {
   sensitive   = true
 }
 
-output "google_assistant_client_id" {
-  value       = cloudflare_access_service_token.google_assistant.client_id
-  description = "Client ID for Google Assistant service token."
-}
-
 output "google_assistant_client_secret" {
   value       = cloudflare_access_service_token.google_assistant.client_secret
   description = "Client secret for Google Assistant service token."

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,3 +3,14 @@ output "servarr_tunnel_token" {
   description = "Token used by a connector to authenticate and run the tunnel."
   sensitive   = true
 }
+
+output "google_assistant_client_id" {
+  value       = cloudflare_access_service_token.google_assistant.client_id
+  description = "Client ID for Google Assistant service token."
+}
+
+output "google_assistant_client_secret" {
+  value       = cloudflare_access_service_token.google_assistant.client_secret
+  description = "Client secret for Google Assistant service token."
+  sensitive   = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "servarr_tunnel_token" {
   description = "Token used by a connector to authenticate and run the tunnel."
   sensitive   = true
 }
+output "google_assistant_client_id" {
+  value       = cloudflare_access_service_token.google_assistant.client_id
+  description = "Client ID for Google Assistant service token."
+  sensitive   = true
+}
 
 output "google_assistant_client_id" {
   value       = cloudflare_access_service_token.google_assistant.client_id

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,8 @@ id qbittorrent &>/dev/null || useradd qbittorrent -u 13007
 id maintainerr &>/dev/null || useradd maintainerr -u 13008
 id tautulli &>/dev/null || useradd tautulli -u 13009
 id wizarr &>/dev/null || useradd wizarr -u 13010
+id homeassistant &>/dev/null || useradd homeassistant -u 13011
+id matter &>/dev/null || useradd matter -u 13012
 
 # Make group (only if it doesn't exist)
 getent group servarr &>/dev/null || groupadd servarr -g 13000
@@ -28,12 +30,14 @@ id -nG qbittorrent 2>/dev/null | grep -qw servarr || usermod -a -G servarr qbitt
 id -nG maintainerr 2>/dev/null | grep -qw servarr || usermod -a -G servarr maintainerr &>/dev/null
 id -nG tautulli 2>/dev/null | grep -qw servarr || usermod -a -G servarr tautulli &>/dev/null
 id -nG wizarr 2>/dev/null | grep -qw servarr || usermod -a -G servarr wizarr &>/dev/null
+id -nG homeassistant 2>/dev/null | grep -qw servarr || usermod -a -G servarr homeassistant &>/dev/null
+id -nG matter 2>/dev/null | grep -qw servarr || usermod -a -G servarr matter &>/dev/null
 
 # Make directories
 mkdir -p /mnt/data/{torrents,media}/{tv,movies,4ktv,4kmovies} &>/dev/null
 mkdir -p /mnt/data/{recordings,optimised}/{tv,movies} &>/dev/null
 mkdir -p /var/tmp/plex &>/dev/null
-mkdir -p config/{plex,overseerr,sonarr,4ksonarr,radarr,4kradarr,bazarr,4kbazarr,prowlarr,qbittorrent,maintainerr,4kmaintainerr,tautulli,wizarr,gluetun,tailscale,ctrld}-config &>/dev/null
+mkdir -p config/{plex,overseerr,sonarr,4ksonarr,radarr,4kradarr,bazarr,4kbazarr,prowlarr,qbittorrent,maintainerr,4kmaintainerr,tautulli,wizarr,gluetun,tailscale,ctrld,home-assistant,matter-server}-config &>/dev/null
 mkdir -p /mnt/kopia &>/dev/null
 mkdir -p /home/nathan/kopia/{config,cache,logs} &>/dev/null
 mkdir -p /home/nathan/uptime-kuma/data &>/dev/null
@@ -64,6 +68,8 @@ chown -R maintainerr:servarr config/maintainerr-config &>/dev/null
 chown -R maintainerr:servarr config/4kmaintainerr-config &>/dev/null
 chown -R tautulli:servarr config/tautulli-config &>/dev/null
 chown -R wizarr:servarr config/wizarr-config &>/dev/null
+chown -R homeassistant:servarr config/home-assistant-config &>/dev/null
+chown -R matter:servarr config/matter-server-config &>/dev/null
 chown -R nathan:servarr config/ctrld-config &>/dev/null
 
 ## Tailscale exit node


### PR DESCRIPTION
This pull request introduces Home Assistant and Matter Server to the stack, including full Docker, user, network, and Cloudflare integration. It also sets up secure access via Cloudflare Access applications and policies for both services.

**Service additions and configuration:**

* Added `home-assistant` and `matter-server` services to `docker-compose.yml`, each with their own containers, environment variables, persistent volumes, and assignment to a new `macvlan1` network with static IPs.
* Created the `macvlan1` Docker network to provide dedicated IP addresses for the new services.

**User and permissions setup:**

* Added `homeassistant` and `matter` system users, assigned them to the `servarr` group, and created their configuration directories with proper ownership in `setup.sh`. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R15-R16) [[2]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R33-R40) [[3]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R71-R72)

**Cloudflare DNS and tunnel configuration:**

* Added Cloudflare DNS `CNAME` records for `ha.nathanjn.com` and `matter.nathanjn.com`, pointing to the tunnel endpoint.
* Updated the Cloudflare tunnel configuration to route `ha.nathanjn.com` to Home Assistant and `matter.nathanjn.com` to Matter Server.

**Cloudflare Access security:**

* Created Cloudflare Access applications and policies for both `ha.nathanjn.com` and `matter.nathanjn.com`, enforcing identity-based and service-token-based access controls.