### PR TITLE
Use host networking for Home Assistant and Matter Server

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -268,11 +268,11 @@ resource "cloudflare_tunnel_config" "servarr_tunnel" {
     }
     ingress_rule {
       hostname = "ha.nathanjn.com"
-      service  = "http://home-assistant:8123"
+      service  = "http://host.docker.internal:8123"
     }
     ingress_rule {
       hostname = "matter.nathanjn.com"
-      service  = "http://matter-server:5580"
+      service  = "http://host.docker.internal:5580"
     }
     ingress_rule {
       service = "http_status:404"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -385,13 +385,10 @@ networks:
     driver: macvlan
     driver_opts:
       parent: enp1s0
-    enable_ipv6: true
     ipam:
       driver: default
       config:
         - subnet: 192.168.8.0/24
           # The ip_range 192.168.8.4/30 provides only 2 usable IP addresses (192.168.8.5 for the container, 192.168.8.6 for the host).
-          ip_range: 192.168.8.0/24
+          ip_range: 192.168.8.4/30
           gateway: 192.168.8.1
-        - subnet: fd69:59dc:f817:b798::/64
-          gateway: fd69:59dc:f817:b798:9683:c4ff:feb4:a502

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,6 +246,8 @@ services:
     image: cloudflare/cloudflared:latest
     container_name: cloudflared
     command: tunnel run --protocol http2
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - TUNNEL_TOKEN=${TUNNEL_TOKEN}
     restart: always
@@ -303,11 +305,7 @@ services:
   home-assistant:
     image: lscr.io/linuxserver/homeassistant:latest
     container_name: home-assistant
-    networks:
-      default:
-      macvlan0:
-        ipv4_address: 192.168.8.13
-        ipv6_address: fd69:59dc:f817:b798::13
+    network_mode: host
     environment:
       - PUID=13011
       - PGID=13000
@@ -325,11 +323,7 @@ services:
     image: ghcr.io/matter-js/matterjs-server:latest
     container_name: matter-server
     user: 13012:13000
-    networks:
-      default:
-      macvlan0:
-        ipv4_address: 192.168.8.14
-        ipv6_address: fd69:59dc:f817:b798::14
+    network_mode: host
     environment:
       - TZ=Australia/Brisbane
     read_only: true


### PR DESCRIPTION
Switch Home Assistant and Matter Server from macvlan to host networking for better mDNS/IoT device discovery.

## Changes

- **`docker-compose.yml`**: Set `network_mode: host` for `home-assistant` and `matter-server`, replacing the dual `default`/`macvlan0` network config
- **`docker-compose.yml`**: Add `extra_hosts: host.docker.internal:host-gateway` to `cloudflared` so the tunnel can reach host-networked services on Linux
- **`docker-compose.yml`**: Restore macvlan0 network to original `ip_range: 192.168.8.4/30` (only used by tailscale-exit-node now)
- **`cloudflare.tf`**: Update tunnel ingress for `ha.nathanjn.com` and `matter.nathanjn.com` to route via `host.docker.internal` instead of container names